### PR TITLE
Coremark now runs on this version of ibex. [ibex_register_file_ff]: a…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 
 # Use a parallel run (make -j N) for a faster build
 build-all: build-riscv-compliance build-simple-system build-arty-100 \
-      build-csr-test
+      build-csr-test run-coremark
 
 
 # RISC-V compliance
@@ -45,6 +45,9 @@ run-simple-system: sw-simple-hello | $(Vibex_simple_system)
 	build/lowrisc_ibex_ibex_simple_system_0/sim-verilator/Vibex_simple_system \
 		--raminit=$(simple-system-program) -t
 
+run-coremark: 
+	make -C ./examples/sw/benchmarks/coremark/
+	build/lowrisc_ibex_ibex_simple_system_0/sim-verilator/Vibex_simple_system --meminit=ram,examples/sw/benchmarks/coremark/coremark.elf 
 
 # Arty A7 FPGA example
 # Use the following targets (depending on your hardware):

--- a/rtl/ibex_core.sv
+++ b/rtl/ibex_core.sv
@@ -97,6 +97,8 @@ module ibex_core #(
   import ibex_pkg::*;
 
   localparam int unsigned PMP_NUM_CHAN = 2;
+  localparam int unsigned REG_FILE_ADDR_WIDTH = RV32E ? 4 : 5;
+  localparam int unsigned SHADOW_STACK_REG_FILE_ADDR_WIDTH = 5;
 
   // IF/ID signals
   logic        instr_valid_id;
@@ -691,8 +693,8 @@ module ibex_core #(
   );
 
   ibex_register_file #(
-      .RV32E(RV32E),
-      .DataWidth(32)
+      .DataWidth(32),
+      .AddrWidth(REG_FILE_ADDR_WIDTH)
   ) register_file_i (
       .clk_i        ( clk_i        ),
       .rst_ni       ( rst_ni       ),
@@ -904,7 +906,8 @@ module ibex_core #(
   end
 
   ibex_shadow_stack #(
-    .RV32E(RV32E)  
+    .RV32E(RV32E),
+    .ADDR_WIDTH(SHADOW_STACK_REG_FILE_ADDR_WIDTH)  
   )
   shadow_stack_inst (
     .clk_i(clk_i),    // Clock

--- a/rtl/ibex_decoder.sv
+++ b/rtl/ibex_decoder.sv
@@ -244,7 +244,9 @@ module ibex_decoder #(
           // Only for function jumps (from reg 0x1).
           // Sample on first cycle, because otherwise it might be an instruction after a
           // branch that was not taken.
+          if(instr[`REG_S1] == 5'b1) begin
             validate_pointer_o = 1'b1;
+          end
           // end
         end else begin
           // Calculate and store PC+4

--- a/rtl/ibex_register_file_ff.sv
+++ b/rtl/ibex_register_file_ff.sv
@@ -11,8 +11,8 @@
  * targeting FPGA synthesis or Verilator simulation.
  */
 module ibex_register_file #(
-    parameter bit RV32E              = 0,
-    parameter int unsigned DataWidth = 32
+    parameter int unsigned DataWidth = 32,
+    parameter int unsigned AddrWidth = 5
 ) (
     // Clock and Reset
     input  logic                 clk_i,
@@ -36,8 +36,7 @@ module ibex_register_file #(
 
 );
 
-  localparam int unsigned ADDR_WIDTH = RV32E ? 4 : 5;
-  localparam int unsigned NUM_WORDS  = 2**ADDR_WIDTH;
+  localparam int unsigned NUM_WORDS  = 2**AddrWidth;
 
   logic [NUM_WORDS-1:0][DataWidth-1:0] rf_reg;
   logic [NUM_WORDS-1:1][DataWidth-1:0] rf_reg_tmp;

--- a/rtl/ibex_shadow_stack.sv
+++ b/rtl/ibex_shadow_stack.sv
@@ -1,5 +1,6 @@
 module ibex_shadow_stack #(
-	parameter bit RV32E = 1'b0
+	parameter bit RV32E = 1'b0,
+	parameter int unsigned ADDR_WIDTH = 8
 )
 (
 	input clk_i,    // Clock
@@ -15,9 +16,10 @@ module ibex_shadow_stack #(
 
 import ibex_pkg::*;
 
-logic [4:0]  stack_top_addr;
-logic [4:0]  rf_waddr_wb;
-logic [4:0]  rf_raddr_a;
+
+logic [ADDR_WIDTH - 1:0]  stack_top_addr;
+logic [ADDR_WIDTH - 1:0]  rf_waddr_wb;
+logic [ADDR_WIDTH - 1:0]  rf_raddr_a;
 logic [31:0] rf_wdata_wb;
 logic [31:0] rf_rdata_a;
 logic 		 rf_we_wb;
@@ -71,8 +73,8 @@ end
 
 
 ibex_register_file #(
-      .RV32E(RV32E),
-      .DataWidth(32)
+      .DataWidth(32),
+      .AddrWidth(8)
   ) register_file_i (
       .clk_i        ( clk_i        ),
       .rst_ni       ( rst_ni       ),


### PR DESCRIPTION
…dded generic for address width. This enables this module to be more generic. [ibex_shadow_stack]: now has generic that determines the depth of the stack. [ibex_decoder]: fixed the trigger for return address validation - now checks only for jal x1, and not for any register in the register file. [Makefile]: added run-coremark command